### PR TITLE
Fix a bug in determining length for tags with length greater then 1 byte

### DIFF
--- a/emv.js
+++ b/emv.js
@@ -61,8 +61,9 @@ function parse(emv_data, callback){
 			lenHex = emv_data.substring(tag.length, tag.length + 2 + byteToBeRead*2)
 			console.log('lenHex: ' + lenHex + ' lenBin: '+ lenBin +' ---> len is more than 1 byte');
 			// 	lenHex = emv_data.substring(tag.length, tag.length + 4);
-			len = util.Hex2Dec(lenHex.substring(1)) * 2;
+			len = util.Hex2Dec(lenHex.substring(2)) * 2;
 			offset = tag.length + 2 + (byteToBeRead*2)+len;
+			console.log('length (decimals): ' + len + ' offset: '+ offset +' - this is for the substring of emv_data');
 		}
 
 		var value = emv_data.substring(tag.length + 2 + (byteToBeRead*2), offset);


### PR DESCRIPTION
Found that but I mentioned to you yesterday.
The error showed up in parsing nested tags.

take a string of EMV tags like this, and run before this fix and after:
```
emv.parse("FC8202279A031705115F2A0208409F02060000000199999F090200969F1A0208409F3303E0F8C89F3501229F37047ABA10D39F4005F200B0B001DFDF530181F481DFDFDF360100DFDF374056D2ED87A81943C918908715E74E59C4DF9385CCE9A66ADEC988C7151FA972B7B24DEC16C87D4AA4CCB870EA89C7B09D27686FCC917BDEBC876D73E7727CDD61DFDF380100DFDF3928E9BE77763CB09B047651F691A4BEE2A1F898270409A60A67A04519867FDCAAC03D8B412D9EF9F731DFDF3A0101DFDF3B00DFDF3C38B10CEF42AC2D06C7B0849F3C29E4A8DC4F6D15FC64F25F54AAFA35F355674CECE480DC3246CC2B952A9C0349757A68E96CF4DE9420DB2CEEDFDF3D0100DFDF430400002200DFDF500A9503720000002A20009BDFDF510181F481DFDFDF360100DFDF374056D2ED87A81943C918908715E74E59C4DF9385CCE9A66ADEC988C7151FA972B7B24DEC16C87D4AA4CCB870EA89C7B09D27686FCC917BDEBC876D73E7727CDD61DFDF380100DFDF3928E9BE77763CB09B047651F691A4BEE2A1F898270409A60A67A04519867FDCAAC03D8B412D9EF9F731DFDF3A0101DFDF3B00DFDF3C38B10CEF42AC2D06C7B0849F3C29E4A8DC4F6D15FC64F25F54AAFA35F355674CECE480DC3246CC2B952A9C0349757A68E96CF4DE9420DB2CEEDFDF3D0100DFDF430400002200DFDF500A9503720000002A20009BDFDF5101819F21031908049F1E0831303037313630469F3901029F410400000019DFDF2508991708411007160F", function(d) { console.log(JSON.stringify(d, null, 2) ) } )
```